### PR TITLE
Docker fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ cli/out/$(TARGET): netpen
 
 $(TARGET): cli/out/$(TARGET)
 
-dev lint pycodestyle validation-tests system-tests:
+dev build-dev dev-ext build-dev-ext lint pycodestyle validation-tests system-tests:
 	$(MAKE) -C dev $@
 
 screenshots:
 	$(MAKE) -C examples $@
 
-.PHONY: $(TARGET) dev lint pycodestyle validation-tests system-tests screenshots
+.PHONY: $(TARGET) dev build-dev dev-ext build-dev-ext lint pycodestyle validation-tests system-tests screenshots

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ and routes.
 ## Examples
 
 ### Simple Router
+
 ![Simple Router](/examples/router.png?raw=true)
 
 The resulting script will create three network namespaces - "a", "b", and "router".
@@ -22,13 +23,13 @@ The resulting script will create three network namespaces - "a", "b", and "route
 Running on a fresh VM:
 
 ```bash
-root@(none):/# ./netpen.sh 
- ____                 _               
-|  _ \   ___   _   _ | |_   ___  _ __ 
+root@(none):/# ./netpen.sh
+ ____                 _
+|  _ \   ___   _   _ | |_   ___  _ __
 | |_) | / _ \ | | | || __| / _ \| '__|
-|  _ < | (_) || |_| || |_ |  __/| |   
-|_| \_\ \___/  \__,_| \__| \___||_|   
-                                      
+|  _ < | (_) || |_| || |_ |  __/| |
+|_| \_\ \___/  \__,_| \__| \___||_|
+
 
 +-----------+------------------------------------+
 | Namespace | IPv4                               |
@@ -59,6 +60,7 @@ PING 198.51.100.1 (198.51.100.2) 56(84) bytes of data.
 64 bytes from 198.51.100.2: icmp_seq=1 ttl=63 time=7.00 ms
 64 bytes from 198.51.100.2: icmp_seq=2 ttl=63 time=0.956 ms
 ```
+
 ## Run Locally
 
 Clone the project
@@ -73,12 +75,38 @@ Go to the project directory
   cd netpen
 ```
 
+Initialize netpen (only needed the first time)
+
+```bash
+  make build-dev
+```
+
 Start the servers
 
 ```bash
   make dev
 ```
+
 This will bring up a local docker-compose based environment. You can then browse to http://localhost:8199/
+
+(Optional) Rebuild the Docker images after modifying if needed
+
+```bash
+  make build-dev
+```
+
+(Optional) Initialize or rebuild netpen with external Docker network, for VPN or other
+
+```bash
+  make build-dev-ext
+```
+
+(Optional) Start servers with external Docker network, for VPN or other
+
+```bash
+  make dev-ext
+```
+
 ## Running Tests
 
 ### Validation Tests
@@ -99,6 +127,7 @@ To run them, use the following command:
 ```bash
   make system-tests
 ```
+
 ## API Reference
 
 #### Generate BASH script
@@ -107,11 +136,12 @@ To run them, use the following command:
   POST /v1/bash
 ```
 
-| Parameter | Type     | Description                |
-| :-------- | :------- | :------------------------- |
-| `body`    | `string` |  **Required**. YAML file describing the network topology |
+| Parameter | Type     | Description                                             |
+| :-------- | :------- | :------------------------------------------------------ |
+| `body`    | `string` | **Required**. YAML file describing the network topology |
 
 You can try this using cURL:
+
 ```bash
 curl --data-binary "@examples/router.yml" https://api.netpen.io/v1/bash
 ```
@@ -123,15 +153,17 @@ cat ./examples/router.yml | http POST https://api.netpen.io/v1/bash
 ```
 
 #### Generate Graphviz DOT document
+
 ```http
   POST /v1/dot
 ```
 
-| Parameter | Type     | Description                |
-| :-------- | :------- | :------------------------- |
-| `body`    | `string` |  **Required**. YAML file describing the network topology |
+| Parameter | Type     | Description                                             |
+| :-------- | :------- | :------------------------------------------------------ |
+| `body`    | `string` | **Required**. YAML file describing the network topology |
 
 You can pipe this via Graphviz, for example:
+
 ```bash
 curl --data-binary "@examples/router.yml" https://api.netpen.io/v1/dot | dot -Tpng | display
 ```
@@ -142,7 +174,6 @@ curl --data-binary "@examples/router.yml" https://api.netpen.io/v1/dot | dot -Tp
 
 **Backend:** Python, Flask (local) / AWS API GW & Lambda (deployed)
 
-  
 ## License
 
 [MIT](https://choosealicense.com/licenses/mit/)

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,6 +1,48 @@
 dev:
 	docker-compose -f docker-compose.yml up
-.PHONY: dev
+
+# Build or rebuild docker containers.
+build-dev:
+ifeq (,$(wildcard /usr/bin/yarn))
+	cd ../web; \
+	sudo apt-get update && sudo apt-get install -y yarn || \
+	apt-get update && sudo apt-get install -y yarn || \
+	sudo pacman --needed --noconfirm -S yarn || \
+	pacman --needed --noconfirm -S yarn; \
+	yarn install && \
+	yarn build; \
+	cd ../dev
+endif
+	docker-compose -f docker-compose.yml build
+
+# Use this target instead of `dev` to support VPN 
+# configs (OpenVPN or other).
+dev-ext:
+	docker-compose -f docker-compose-ext-net.yml up
+
+# Build or rebuild docker containers (external network version).
+# A feature to specify the subnet from the command-line 
+# may be added. The below subnet address may need to be 
+# different for your network.
+build-dev-ext:
+ifeq (,$(wildcard /usr/bin/yarn))
+	cd ../web; \
+	sudo apt-get update && sudo apt-get install -y yarn || \
+	apt-get update && sudo apt-get install -y yarn || \
+	sudo pacman --needed --noconfirm -S yarn || \
+	pacman --needed --noconfirm -S yarn; \
+	yarn install && \
+	yarn build; \
+	cd ../dev
+endif
+	docker network create --subnet 10.0.12.1/24 netpen-docker-compose-net; \
+	docker-compose -f docker-compose-ext-net.yml build
+
+.PHONY: \
+	dev \
+	build-dev \
+	dev-ext \
+	build-dev-ext
 
 validation-tests system-tests:
 	$(MAKE) -C tests/$@

--- a/dev/docker-compose-ext-net.yml
+++ b/dev/docker-compose-ext-net.yml
@@ -1,0 +1,43 @@
+version: "3"
+networks:
+    default:
+        external:
+            name: netpen-docker-compose-net
+services:
+    rest:
+        build:
+           context: ..
+           dockerfile: ./dev/rest/Dockerfile
+        container_name: netpen-rest
+        volumes:
+           - ..:/app
+        ports:
+           - 5000:5000
+        environment:
+          - FLASK_APP=./dev/rest/__main__.py
+    examples:
+        image: nginx
+        ports:
+            - 8866:80
+        volumes:
+            - ../examples:/usr/share/nginx/html:ro
+            - ../dev/nginx/examples:/etc/nginx/conf.d/
+    demuxer:
+        image: nginx
+        ports:
+            - 8199:80
+        volumes:
+            - ../dev/nginx/demuxer:/etc/nginx/conf.d/
+    web:
+        build:
+           context: ..
+           dockerfile: ./web/Dockerfile
+        container_name: netpen-web
+        entrypoint: yarn start
+        environment:
+            - REACT_APP_API_BASE=/
+            - REACT_APP_EXAMPLES_BASE=/example-files/
+        volumes:
+            - ../web:/app
+        ports:
+            - 3000:3000

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -11,6 +11,7 @@ services:
            - 5000:5000
         environment:
           - FLASK_APP=./dev/rest/__main__.py
+          - FLASK_ENV=development
     examples:
         image: nginx
         ports:

--- a/netpen/netdev.py
+++ b/netpen/netdev.py
@@ -102,10 +102,10 @@ class NetDev():
             self.p('ip -net %s link set %s mtu %s' % (self.ns.name, self.name,
                                                       self.mtu))
         for a in self.addrs:
-            dad = 'nodad' if net_family(a) == socket.AF_INET6 else ''
-            self.p('ip %s -net %s addr add %s dev %s %s' % (_flag6(a),
-                                                            self.ns.name,
-                                                            a, self.name, dad))
+            dad = ' nodad' if net_family(a) == socket.AF_INET6 else ''
+            self.p('ip %s -net %s addr add %s dev %s%s' % (_flag6(a),
+                                                           self.ns.name,
+                                                           a, self.name, dad))
         for k, v in self.ethtool.items():
             val = 'on' if v else 'off'
             self.p('ip netns exec %s ethtool -K %s %s %s' % (self.ns.name,


### PR DESCRIPTION
    Add new dev/ Makefile targets:
    
    build-dev
            install dependencies if needed,
            and rebuild docker images
    
    dev-ext
            run with an external Docker network,
            it's needed if you have a VPN client
            or something else on your machine,
            OpenVPN for example.
    
    build-dev-ext
            build images as above, but for external
            Docker network instead
    
    See new file `dev/docker-compose-ext-net.yml`.
    It's the same as the other docker-compose file,
    but with a docker network config added at the
    top.
    
    Add documentation to README.md about these new
    Makefile targets.